### PR TITLE
Fix nil pointer dereference in zstd decompresser example code

### DIFF
--- a/content/docs/example/decompress-zstandard.md
+++ b/content/docs/example/decompress-zstandard.md
@@ -22,7 +22,7 @@ client.AddContentDecompresser("zstd", decompressZstd)
 
 // Create Zstandard decompress logic
 func decompressZstd(r io.ReadCloser) (io.ReadCloser, error) {
-	zr, err := zstd.NewReader(r, nil)
+	zr, err := zstd.NewReader(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Passing `nil` as the second argument to the `zstd.NewReader` func yield a nil pointer dereference panic

https://github.com/klauspost/compress/blob/d140606c3ebe8acc96157ebac19443621dd73c76/zstd/decoder.go#L87