### PR TITLE
Upgrade docs theme to v12

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -34,30 +34,29 @@ type: docs
 <div class="resty-go-min">Minimum required Go version is {{% param Resty.V3.GoMinVersion %}}</div>
 
 {{% columns %}}
-```go
-// HTTP, REST Client
-client := resty.New()
-defer client.Close()
+- ```go
+  // HTTP, REST Client
+  client := resty.New()
+  defer client.Close()
+  
+  res, err := client.R().
+      EnableTrace().
+      Get("https://httpbin.org/get")
+  fmt.Println(err, res)
+  fmt.Println(res.Request.TraceInfo())
+  ```
 
-res, err := client.R().
-    EnableTrace().
-    Get("https://httpbin.org/get")
-fmt.Println(err, res)
-fmt.Println(res.Request.TraceInfo())
-```
-<--->
-```go
-// Server-Sent Events Client
-es := NewEventSource().
-    SetURL("https://sse.dev/test").
-    OnMessage(func(e any) {
-        fmt.Println(e.(*resty.Event))
-    }, nil)
-
-err := es.Get()
-fmt.Println(err)
-```
-
+- ```go
+  // Server-Sent Events Client
+  es := NewEventSource().
+      SetURL("https://sse.dev/test").
+      OnMessage(func(e any) {
+          fmt.Println(e.(*resty.Event))
+      }, nil)
+  
+  err := es.Get()
+  fmt.Println(err)
+  ```
 {{% /columns %}}
 
 <p align="center">Resty v3 offers improved performance, memory efficiency, and features compared to Resty v2.</p>
@@ -67,6 +66,7 @@ This website represents Resty v3 and above. For previous v2 documentation, refer
 ## Key Features
 
 {{% columns %}}
+
 * Simple and chainable methods
 * Multipart and Form data with ease
 * Request Path Params
@@ -78,8 +78,6 @@ This website represents Resty v3 and above. For previous v2 documentation, refer
 * Request tracing
 * CURL command generation
 * HTTP/1.1 and HTTP/2. Integrate HTTP/3
-
-
 <p class="ml-20">and much more ...</p>
 
 <--->
@@ -95,8 +93,8 @@ This website represents Resty v3 and above. For previous v2 documentation, refer
 * Bazel support
 * Dynamic reload of TLS certificates
 * Custom root and client certificates
-
 <p class="ml-20">and much more ...</p>
+
 {{% /columns %}}
 
 ## Highly Extensible

--- a/content/docs/authentication.md
+++ b/content/docs/authentication.md
@@ -22,9 +22,8 @@ client.R().
 
 ## Digest Auth
 
-{{% hint info %}}
-Digest auth is supported only at the client level; create a dedicated client to utilize it.
-{{% /hint %}}
+> [!NOTE]
+> Digest auth is supported only at the client level; create a dedicated client to utilize it.
 
 Supported QOP -
 * `auth`
@@ -48,9 +47,8 @@ client.SetDigestAuth("username", "password")
 
 ## Bearer Auth Token
 
-{{% hint info %}}
-The default auth scheme is `Bearer`, which can be changed with [Client.SetAuthScheme]({{% godoc v3 %}}Client.SetAuthScheme) or [Request.SetAuthScheme]({{% godoc v3 %}}Request.SetAuthScheme)
-{{% /hint %}}
+> [!NOTE]
+> The default auth scheme is `Bearer`, which can be changed with [Client.SetAuthScheme]({{% godoc v3 %}}Client.SetAuthScheme) or [Request.SetAuthScheme]({{% godoc v3 %}}Request.SetAuthScheme)
 
 ```go
 // for all requests
@@ -68,10 +66,9 @@ client.R().
 
 For application/service that user custom HTTP header for authentication/authorization.
 
-{{% hint info %}}
-* The default authorization key is `Authorization`.
-* The default auth scheme is `Bearer`, which can be changed with [Client.SetAuthScheme]({{% godoc v3 %}}Client.SetAuthScheme) or [Request.SetAuthScheme]({{% godoc v3 %}}Request.SetAuthScheme)
-{{% /hint %}}
+> [!NOTE]
+> * The default authorization key is `Authorization`.
+> * The default auth scheme is `Bearer`, which can be changed with [Client.SetAuthScheme]({{% godoc v3 %}}Client.SetAuthScheme) or [Request.SetAuthScheme]({{% godoc v3 %}}Request.SetAuthScheme)
 
 ```go
 client.SetHeaderAuthorizationKey("X-Custom-Auth")

--- a/content/docs/circuit-breaker.md
+++ b/content/docs/circuit-breaker.md
@@ -3,9 +3,8 @@
 
 A circuit breaker is used to improve system stability and resiliency. It is different from the retry mechanism.
 
-{{% hint info %}}
-**Hint:** Combining the Circuit Breaker with [Retry Mechanism]({{% relref "retry-mechanism" %}}) typically provides a comprehensive approach to handling failures.
-{{% /hint %}}
+> [!NOTE]
+> **Hint:** Combining the Circuit Breaker with [Retry Mechanism]({{% relref "retry-mechanism" %}}) typically provides a comprehensive approach to handling failures.
 
 ## Default Values
 

--- a/content/docs/client-root-certificates.md
+++ b/content/docs/client-root-certificates.md
@@ -6,10 +6,9 @@ weight: 6
 
 Resty offers a convenient method to add `client root` certificates.
 
-{{% hint info %}}
-* Starting v3, Resty lets a watcher reload certificates dynamically at configured intervals if modified.
-* Default watcher reload interval is 24 hours.
-{{% /hint %}}
+> [!NOTE]
+> * Starting v3, Resty lets a watcher reload certificates dynamically at configured intervals if modified.
+> * Default watcher reload interval is 24 hours.
 
 ## Examples
 

--- a/content/docs/content-decompresser.md
+++ b/content/docs/content-decompresser.md
@@ -6,12 +6,11 @@ weight: 7
 
 Resty v3 provides an extensible way to handle Response content decompression. Out-of-the-box, it handles `gzip` and `deflate` decompress.
 
-{{% hint info %}}
-**NOTE:**
-* User-defined decompresser takes priority over default ones.
-* Add method overwrites decompresser if `decompress` directive/key already exists.
-* [Content-Encoding directive/key](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) is important while adding decompresser.
-{{% /hint %}}
+> [!NOTE]
+> **NOTE:**
+> * User-defined decompresser takes priority over default ones.
+> * Add method overwrites decompresser if `decompress` directive/key already exists.
+> * [Content-Encoding directive/key](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) is important while adding decompresser.
 
 ## Example
 

--- a/content/docs/content-type-encoder-and-decoder.md
+++ b/content/docs/content-type-encoder-and-decoder.md
@@ -7,11 +7,10 @@ weight: 7
 
  Resty v3 provides an extensible way to handle Request and Response content types. Out-of-the-box, it handles `JSON` and `XML` content types.
 
-{{% hint info %}}
-**NOTE:**
-* User-defined encoder/decoder takes priority over default ones.
-* Add method overwrites encoder/decoder if `Content-Type` key already exists.
-{{% /hint %}}
+> [!NOTE]
+> **NOTE:**
+> * User-defined encoder/decoder takes priority over default ones.
+> * Add method overwrites encoder/decoder if `Content-Type` key already exists.
 
 ## Examples
 

--- a/content/docs/curl-command.md
+++ b/content/docs/curl-command.md
@@ -7,12 +7,11 @@ By default, Resty does not log the curl command in the debug log since it has th
 
 {{% hintreqoverride %}}
 
-{{% hint warning %}}
-**NOTE:**
-   - Potential to leak sensitive data from [Request]({{% godoc v3 %}}Request) and [Response]({{% godoc v3 %}}Response) in the debug log when the debug log option is enabled.
-   - Additional memory usage since the request body was reread.
-   - curl body is not generated for `io.Reader` and multipart request flow.
-{{% /hint %}}
+> [!WARNING]
+> **NOTE:**
+> - Potential to leak sensitive data from [Request]({{% godoc v3 %}}Request) and [Response]({{% godoc v3 %}}Response) in the debug log when the debug log option is enabled.
+> - Additional memory usage since the request body was reread.
+> - curl body is not generated for `io.Reader` and multipart request flow.
 
 ## Example
 

--- a/content/docs/example/decompress-brotli.md
+++ b/content/docs/example/decompress-brotli.md
@@ -3,9 +3,8 @@
 
 Resty v3 allows users to add decompression logic for HTTP responses using their favorite package.
 
-{{% hint info %}}
-Using `sync.Pool` can reuse the reader and reduce allocation if the package supports `Reset`.
-{{% /hint %}}
+> [!NOTE]
+> Using `sync.Pool` can reuse the reader and reduce allocation if the package supports `Reset`.
 
 ## Example 1
 

--- a/content/docs/example/decompress-zstandard.md
+++ b/content/docs/example/decompress-zstandard.md
@@ -3,9 +3,8 @@
 
 Resty v3 allows users to add decompression logic for HTTP responses using their favorite package.
 
-{{% hint info %}}
-Using `sync.Pool` can reuse the reader and reduce allocation if the package supports `Reset`.
-{{% /hint %}}
+> [!NOTE]
+> Using `sync.Pool` can reuse the reader and reduce allocation if the package supports `Reset`.
 
 ## Example
 

--- a/content/docs/example/delete-request.md
+++ b/content/docs/example/delete-request.md
@@ -7,10 +7,9 @@ weight: 2
 
 This page discusses simple DELETE requests. Users can utilize Resty features across nearly all HTTP methods.
 
-{{% hint info %}}
-* Explore the documentation to fulfill all use cases.
-* Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
-{{% /hint %}}
+> [!NOTE]
+> * Explore the documentation to fulfill all use cases.
+> * Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
 
 ## Examples
 

--- a/content/docs/example/get-request.md
+++ b/content/docs/example/get-request.md
@@ -7,10 +7,9 @@ weight: 1
 
 This page discusses simple GET requests. Users can utilize Resty features across nearly all HTTP methods.
 
-{{% hint info %}}
-* Explore the documentation to fulfill all use cases.
-* Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
-{{% /hint %}}
+> [!NOTE]
+> * Explore the documentation to fulfill all use cases.
+> * Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
 
 ## Examples
 

--- a/content/docs/example/oauth2-client-credentials.md
+++ b/content/docs/example/oauth2-client-credentials.md
@@ -9,10 +9,9 @@ title: OAuth2 Client Credentials
 
 ## Without Modifying
 
-{{% hint info %}}
-As per the GoDoc of [clientcredentials#Config.Client](https://pkg.go.dev/golang.org/x/oauth2/clientcredentials#Config.Client)
-* The returned `Client` and its `Transport` should not be modified.
-{{% /hint %}}
+> [!NOTE]
+> As per the GoDoc of [clientcredentials#Config.Client](https://pkg.go.dev/golang.org/x/oauth2/clientcredentials#Config.Client)
+> * The returned `Client` and its `Transport` should not be modified.
 
 ```go
 clientCredCfg := &clientcredentials.Config{
@@ -34,11 +33,10 @@ defer c.Close()
 
 This scenario applies to any client and transport-related configurations, such as adding Root CA, Client Root CA, Client SSL certificates, transport timeouts, and so on.
 
-{{% hint info %}}
-* As per the GoDoc of [clientcredentials#Config.Client](https://pkg.go.dev/golang.org/x/oauth2/clientcredentials#Config.Client)
-    * The returned `Client` and its `Transport` should not be modified.
-* To use the oauth2 client credentials package and make modifications to it, a minor adjustment is necessary.
-{{% /hint %}}
+> [!NOTE]
+> * As per the GoDoc of [clientcredentials#Config.Client](https://pkg.go.dev/golang.org/x/oauth2/clientcredentials#Config.Client)
+>     * The returned `Client` and its `Transport` should not be modified.
+> * To use the oauth2 client credentials package and make modifications to it, a minor adjustment is necessary.
 
 ```go
 clientCredCfg := &clientcredentials.Config{

--- a/content/docs/example/options-head-trace-request.md
+++ b/content/docs/example/options-head-trace-request.md
@@ -7,10 +7,9 @@ weight: 2
 
 This page discusses simple OPTIONS, HEAD, and TRACE requests. Users can utilize Resty features across nearly all HTTP methods.
 
-{{% hint info %}}
-* Explore the documentation to fulfill all use cases.
-* Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
-{{% /hint %}}
+> [!NOTE]
+> * Explore the documentation to fulfill all use cases.
+> * Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
 
 ## Examples
 

--- a/content/docs/example/post-put-patch-request.md
+++ b/content/docs/example/post-put-patch-request.md
@@ -7,10 +7,9 @@ weight: 1
 
 This page discusses simple POST, PUT, and PATCH requests. Users can utilize Resty features across nearly all HTTP methods.
 
-{{% hint info %}}
-* Explore the documentation to fulfill all use cases.
-* Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
-{{% /hint %}}
+> [!NOTE]
+> * Explore the documentation to fulfill all use cases.
+> * Examples use request-level methods; however, Resty also includes client-level methods to configure settings for all requests.
 
 ## Examples
 

--- a/content/docs/form-data.md
+++ b/content/docs/form-data.md
@@ -3,11 +3,10 @@
 
 Resty provides a convenient method to compose form-data requests.
 
-{{% hint info %}}
-* By default, only allowed on payload-supported HTTP verbs, see [allow payload on]({{% relref "allow-payload-on" %}}).
-* Request `Content-Type` set as `application/x-www-form-urlencoded`.
-* Form data values are `URL-encoded`.
-{{% /hint %}}
+> [!NOTE]
+> * By default, only allowed on payload-supported HTTP verbs, see [allow payload on]({{% relref "allow-payload-on" %}}).
+> * Request `Content-Type` set as `application/x-www-form-urlencoded`.
+> * Form data values are `URL-encoded`.
 
 {{% hintreqoverride %}}
 

--- a/content/docs/load-balancer-and-service-discovery.md
+++ b/content/docs/load-balancer-and-service-discovery.md
@@ -10,10 +10,9 @@ Out of the box, Resty provides two algorithms -
 
 Also, SRV records discovery using the Weighted Round-Robin (WRR) algorithm, called []().
 
-{{% hint info %}}
-* Version 2 had an SRV record lookup feature but did not utilize a record weight value. Version 3 respects the record weight value and executes the appropriate weighted round-robin.
-* Version 3 enables Resty users to implement any custom method for determining the Base URL through the [LoadBalancer]({{% godoc v3 %}}LoadBalancer) interface.
-{{% /hint %}}
+> [!NOTE]
+> * Version 2 had an SRV record lookup feature but did not utilize a record weight value. Version 3 respects the record weight value and executes the appropriate weighted round-robin.
+> * Version 3 enables Resty users to implement any custom method for determining the Base URL through the [LoadBalancer]({{% godoc v3 %}}LoadBalancer) interface.
 
 ## Examples
 

--- a/content/docs/multipart.md
+++ b/content/docs/multipart.md
@@ -3,12 +3,11 @@
 
 Resty provides a convenient method to compose multipart form-data or ordered form-data requests.
 
-{{% hint info %}}
-* Only allowed on POST, PUT, and PATCH verbs.
-* Starting v3, ordered multipart form data is possible.
-* [Request.SetMultipartBoundary]({{% godoc v3 %}}Request.SetMultipartBoundary) setting custom boundary can be used together.
-* All form data and multipart methods can be used together.
-{{% /hint %}}
+> [!NOTE]
+> * Only allowed on POST, PUT, and PATCH verbs.
+> * Starting v3, ordered multipart form data is possible.
+> * [Request.SetMultipartBoundary]({{% godoc v3 %}}Request.SetMultipartBoundary) setting custom boundary can be used together.
+> * All form data and multipart methods can be used together.
 
 ```go
 res, err := client.R().
@@ -70,12 +69,11 @@ fmt.Println(err, res)
 
 # Multipart File Upload
 
-{{% hint info %}}
-* By default, Resty streams the content in the request body when a file or `io.Reader` is detected in the MultipartField input.
-* Only allowed on POST, PUT, and PATCH verbs.
-* [Request.SetMultipartBoundary]({{% godoc v3 %}}Request.SetMultipartBoundary) setting custom boundary can be used together.
-* All form data and multipart methods can be used together.
-{{% /hint %}}
+> [!NOTE]
+> * By default, Resty streams the content in the request body when a file or `io.Reader` is detected in the MultipartField input.
+> * Only allowed on POST, PUT, and PATCH verbs.
+> * [Request.SetMultipartBoundary]({{% godoc v3 %}}Request.SetMultipartBoundary) setting custom boundary can be used together.
+> * All form data and multipart methods can be used together.
 
 ## Upload
 

--- a/content/docs/redirect-policy.md
+++ b/content/docs/redirect-policy.md
@@ -9,9 +9,8 @@ Out of the box, it has following redirect polices:
 * [FlexibleRedirectPolicy]({{% godoc v3 %}}FlexibleRedirectPolicy)
 * [DomainCheckRedirectPolicy]({{% godoc v3 %}}DomainCheckRedirectPolicy)
 
-{{% hint info %}}
-v3 [NoRedirectPolicy]({{% godoc v3 %}}NoRedirectPolicy) returns an error `http.ErrUseLastResponse`.
-{{% /hint %}}
+> [!NOTE]
+> v3 [NoRedirectPolicy]({{% godoc v3 %}}NoRedirectPolicy) returns an error `http.ErrUseLastResponse`.
 
 ## Example
 

--- a/content/docs/request-body-types.md
+++ b/content/docs/request-body-types.md
@@ -6,17 +6,15 @@ weight: 4
 
 Resty supports various request body types.
 
-{{% hint info %}}
-* Resty v3 streams the content in the request body for the `io.Reader` interface.
-* Setting the Content-Type header in the request skips the auto-detect computation.
-* It does request body automatic marshaling for `struct` and `map` data types.
-{{% /hint %}}
+> [!NOTE]
+> * Resty v3 streams the content in the request body for the `io.Reader` interface.
+> * Setting the Content-Type header in the request skips the auto-detect computation.
+> * It does request body automatic marshaling for `struct` and `map` data types.
 
 ## Struct
 
-{{% hint info %}}
-For the `XML` request body, set Content-Type as `application/xml`.
-{{% /hint %}}
+> [!NOTE]
+> For the `XML` request body, set Content-Type as `application/xml`.
 
 ```go
 res, err := client.R().
@@ -74,11 +72,10 @@ fmt.Println(err, res)
 
 ## io.Reader
 
-{{% hint info %}}
-Resty v3,
-* Streams the content in the request body for the `io.Reader` interface.
-* The content length option no longer applies to the `io.Reader` flow.
-{{% /hint %}}
+> [!NOTE]
+> Resty v3,
+> * Streams the content in the request body for the `io.Reader` interface.
+> * The content length option no longer applies to the `io.Reader` flow.
 
 ```go
 res, err := client.R().

--- a/content/docs/request-middleware.md
+++ b/content/docs/request-middleware.md
@@ -10,11 +10,10 @@ Out of the box, it has -
 
 * [PrepareRequestMiddleware]({{% godoc v3 %}}PrepareRequestMiddleware)
 
-{{% hint info %}}
-* v3 introduces a fully composable middleware feature that allows the registration of request middleware in any order to accommodate practical use cases.
-* v3 introduces [Request.Funcs]({{% godoc v3 %}}Request.Funcs) feature that could help to perform Request instance manipulation.
-* `Request.RawRequest` instance available after `PrepareRequestMiddleware` middleware execution.
-{{% /hint %}}
+> [!NOTE]
+> * v3 introduces a fully composable middleware feature that allows the registration of request middleware in any order to accommodate practical use cases.
+> * v3 introduces [Request.Funcs]({{% godoc v3 %}}Request.Funcs) feature that could help to perform Request instance manipulation.
+> * `Request.RawRequest` instance available after `PrepareRequestMiddleware` middleware execution.
 
 ## Examples
 

--- a/content/docs/response-auto-parse.md
+++ b/content/docs/response-auto-parse.md
@@ -27,9 +27,8 @@ fmt.Println(res.Error().(*LoginError))
 
 ### SetResult and SetError Usage
 
-{{% hint info %}}
-Examples describe the method `SetResult`, which applies to `SetError`.
-{{% /hint %}}
+> [!NOTE]
+> Examples describe the method `SetResult`, which applies to `SetError`.
 
 #### Usage 1 - Inline Pointer
 
@@ -82,11 +81,10 @@ client.R().SetForceResponseContentType("application/json")
 
 To prevent automatic response parsing for the particular use case, use this setting.
 
-{{% hint warning %}}
-Using the do not parse option means:
-* You have taken over the control of response body parsing from Resty.
-* Do not forget to close the response body. Otherwise, you might get into connection leaks, and connection reuse may not happen.
-{{% /hint %}}
+> [!WARNING]
+> Using the do not parse option means:
+> * You have taken over the control of response body parsing from Resty.
+> * Do not forget to close the response body. Otherwise, you might get into connection leaks, and connection reuse may not happen.
 
 {{% hintreqoverride %}}
 

--- a/content/docs/response-middleware.md
+++ b/content/docs/response-middleware.md
@@ -11,10 +11,9 @@ Out of the box, it has -
 * [AutoParseResponseMiddleware]({{% godoc v3 %}}AutoParseResponseMiddleware)
 * [SaveToFileResponseMiddleware]({{% godoc v3 %}}SaveToFileResponseMiddleware)
 
-{{% hint info %}}
-* v3 introduces a fully composable middleware feature that allows the registration of response middleware in any order to accommodate practical use cases.
-* v3 introduces the capability to cascade an error within the response middleware execution chain.
-{{% /hint %}}
+> [!NOTE]
+> * v3 introduces a fully composable middleware feature that allows the registration of response middleware in any order to accommodate practical use cases.
+> * v3 introduces the capability to cascade an error within the response middleware execution chain.
 
 ## Examples
 

--- a/content/docs/retry-mechanism.md
+++ b/content/docs/retry-mechanism.md
@@ -5,9 +5,8 @@ The retry mechanism plays a crucial role in modern system integration by enablin
 
 Resty provides exponential backoff with a jitter strategy out of the box; a custom retry strategy could be employed to override this default.
 
-{{% hint info %}}
-**Hint:** Combining the Retry strategy with [Circuit Breaker]({{% relref "circuit-breaker" %}}) typically provides a comprehensive approach to handling failures.
-{{% /hint %}}
+> [!NOTE]
+> **Hint:** Combining the Retry strategy with [Circuit Breaker]({{% relref "circuit-breaker" %}}) typically provides a comprehensive approach to handling failures.
 
 {{% hintreqoverride %}}
 

--- a/content/docs/root-certificates.md
+++ b/content/docs/root-certificates.md
@@ -6,10 +6,9 @@ weight: 5
 
 Resty offers a convenient method to add `root` certificates.
 
-{{% hint info %}}
-* Starting v3, Resty lets a watcher reload certificates dynamically at configured intervals if modified.
-* Default watcher reload interval is 24 hours.
-{{% /hint %}}
+> [!NOTE]
+> * Starting v3, Resty lets a watcher reload certificates dynamically at configured intervals if modified.
+> * Default watcher reload interval is 24 hours.
 
 ## Examples
 

--- a/content/docs/save-response.md
+++ b/content/docs/save-response.md
@@ -6,15 +6,14 @@ weight: 4
 
 Resty provides a simple method for saving/downloading HTTP responses to the file system.
 
-{{% hint info %}}
-Resty v3 adds -
-* Ability to determine the filename automatically from the response in the following order -
-    * [Request.SetOutputFileName]({{% godoc v3 %}}Request.SetOutputFileName)
-    * Header `Content-Disposition`
-    * Request URL using `path.Base`
-    * Request URL hostname if path is empty or "/"
-* Ability to use [Request.SetResult]({{% godoc v3 %}}Request.SetResult) and [Request.SetError]({{% godoc v3 %}}Request.SetError) together with save response by enabling [Request.SetResponseBodyUnlimitedReads]({{% godoc v3 %}}Request.SetResponseBodyUnlimitedReads), refer to [unlimited response reads]().
-{{% /hint %}}
+> [!NOTE]
+> Resty v3 adds -
+> * Ability to determine the filename automatically from the response in the following order -
+>     * [Request.SetOutputFileName]({{% godoc v3 %}}Request.SetOutputFileName)
+>     * Header `Content-Disposition`
+>     * Request URL using `path.Base`
+>     * Request URL hostname if path is empty or "/"
+> * Ability to use [Request.SetResult]({{% godoc v3 %}}Request.SetResult) and [Request.SetError]({{% godoc v3 %}}Request.SetError) together with save response by enabling [Request.SetResponseBodyUnlimitedReads]({{% godoc v3 %}}Request.SetResponseBodyUnlimitedReads), refer to [unlimited response reads]().
 
 {{% hintreqoverride %}}
 

--- a/content/docs/timeout.md
+++ b/content/docs/timeout.md
@@ -9,9 +9,8 @@ Resty v3 allows users to modify all timeout values utilized in the implementatio
 
 ### Transport Timeouts
 
-{{% hint info %}}
-Refer to `godoc` to know all supported fields and their default values, [TransportSettings]({{% godoc v3 %}}TransportSettings).
-{{% /hint %}}
+> [!NOTE]
+> Refer to `godoc` to know all supported fields and their default values, [TransportSettings]({{% godoc v3 %}}TransportSettings).
 
 ```go
 // create transport with timeouts
@@ -29,9 +28,8 @@ defer c.Close()
 
 ### Client Timeout
 
-{{% hint info %}}
-Resty v3 does not use `http.Client.Timeout`.
-{{% /hint %}}
+> [!NOTE]
+> Resty v3 does not use `http.Client.Timeout`.
 
 ```go
 client.SetTimeout(2 * time.Minute)
@@ -39,10 +37,9 @@ client.SetTimeout(2 * time.Minute)
 
 ### Request Timeout
 
-{{% hint info %}}
-* It overrides the client-level timeout value.
-* It does not set a timeout if the user has already set a timeout/deadline.
-{{% /hint %}}
+> [!NOTE]
+> * It overrides the client-level timeout value.
+> * It does not set a timeout if the user has already set a timeout/deadline.
 
 ```go
 // set timeout for current request

--- a/content/docs/unlimited-response-body-reads.md
+++ b/content/docs/unlimited-response-body-reads.md
@@ -3,9 +3,8 @@
 
 Resty v3 provides the ability to read HTTP response body unlimited times.
 
-{{% hint warning %}}
-* Keeps the response body in memory, which might cause additional memory usage.
-{{% /hint %}}
+> [!WARNING]
+> * Keeps the response body in memory, which might cause additional memory usage.
 
 {{% hintreqoverride %}}
 

--- a/content/docs/upgrading-to-v3.md
+++ b/content/docs/upgrading-to-v3.md
@@ -6,9 +6,8 @@ bookHidden: true
 
 Resty v3 release brings many new features, enhancements, and breaking changes. This page outlines upgrading Resty to v3.
 
-{{% hint info %}}
-Minimum required go version is `{{% param Resty.V3.GoMinVersion %}}`
-{{% /hint %}}
+> [!NOTE]
+> Minimum required go version is `{{% param Resty.V3.GoMinVersion %}}`
 
 ## Update go.mod
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-resty/docs
 
 go 1.22.0
 
-require github.com/alex-shpak/hugo-book v0.0.0-20241009212754-7c78a39c531a // indirect
+require github.com/alex-shpak/hugo-book/v12 v12.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/alex-shpak/hugo-book v0.0.0-20241009212754-7c78a39c531a h1:GiRJQYc9Bt8H59/e0w/97i46Ql39CUIdDQjHikd9scA=
-github.com/alex-shpak/hugo-book v0.0.0-20241009212754-7c78a39c531a/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
+github.com/alex-shpak/hugo-book/v12 v12.0.0 h1:PNRH6nqTCZwK/8R93J6bYOWWBbM1emtnZjgW9sPoqwI=
+github.com/alex-shpak/hugo-book/v12 v12.0.0/go.mod h1:f6/H1eOdaReIR+EHPkZGEvmgdRzKLjZek/CaTqBOyho=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -27,11 +27,11 @@ markup:
 menu:
   before:
     - name: "Upgrading to v3"
-      url: "/docs/upgrading-to-v3/"
+      pageRef: "/docs/upgrading-to-v3/"
       weight: 10
     - name: "New Features and Enhancements"
       parent: "Upgrading to v3"
-      url: "/docs/new-features-and-enhancements/"
+      pageRef: "/docs/new-features-and-enhancements/"
       weight: 20
 
 params:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,5 @@
 baseURL: https://resty.dev/
 title: Resty
-theme: hugo-book
 
 languageCode: en-us
 cleanDestinationDir: true
@@ -9,13 +8,9 @@ cleanDestinationDir: true
 # permalinks:
 #   posts: ":filename"
 
-# module:
-#   imports:
-#     - path: github.com/alex-shpak/hugo-book
-#       disable: false
-
-theme:
-  - github.com/alex-shpak/hugo-book
+module:
+  imports:
+    - path: github.com/alex-shpak/hugo-book/v12
 
 # Needed for mermaid/katex shortcodes
 markup:
@@ -29,18 +24,15 @@ markup:
   highlight:
     style: base16-snazzy
 
-# menu:
-#   before:
-#     - name: Home
-#       url: "/"
-#       weight: 10
-  # after:
-  #   - name: "Github"
-  #     url: "https://github.com/alex-shpak/hugo-book"
-  #     weight: 10
-  #   - name: "Hugo Themes"
-  #     url: "https://themes.gohugo.io/themes/hugo-book/"
-  #     weight: 20
+menu:
+  before:
+    - name: "Upgrading to v3"
+      url: "/docs/upgrading-to-v3/"
+      weight: 10
+    - name: "New Features and Enhancements"
+      parent: "Upgrading to v3"
+      url: "/docs/new-features-and-enhancements/"
+      weight: 20
 
 params:
   # Resty site variables
@@ -56,9 +48,9 @@ params:
 
   # (Optional, default light) Sets color theme: light, dark or auto.
   # Theme 'auto' switches between dark and light modes based on browser/os preferences
-  BookTheme: auto
+  BookTheme: "auto"
 
-  # (Optional, default true) Controls table of contents visibility on right side of pages.
+  # (Optional, default none) Controls table of contents visibility on right side of pages.
   # Start and end levels can be controlled with markup.tableOfContents setting.
   # You can also specify this parameter per page in front matter.
   BookToC: true
@@ -76,31 +68,26 @@ params:
   # For backward compatibility you can set '*' to render all sections to menu. Acts same as '/'
   BookSection: docs
 
-  # Set source repository location.
-  # Used for 'Last Modified' and 'Edit this page' links.
-  BookRepo: https://github.com/go-resty/docs
+  # (Optional, default none) Set template for commit link for the page. Requires enableGitInfo.
+  # When set enabled 'Last Modified' and a link to the commit in the footer of the page.
+  # Param is executed as template using .Site, .Page and .GitInfo as context.
+  BookLastChangeLink: 'https://github.com/go-resty/docs/commit/{{ .GitInfo.Hash }}'
 
-  # (Optional, default 'commit') Specifies commit portion of the link to the page's last modified
-  # commit hash for 'doc' page type.
-  # Requires 'BookRepo' param.
-  # Value used to construct a URL consisting of BookRepo/BookCommitPath/<commit-hash>
-  # Github uses 'commit', Bitbucket uses 'commits'
-  # BookCommitPath: commit
+  # (Optional, default none) Set template for edit page link.
+  # When set enabled 'Edit this page' link in the footer of the page.
+  # Param is executed as template using .Site, .Page and .Path as context.
+  BookEditLink: 'https://github.com/go-resty/docs/edit/main/exampleSite/{{ .Path }}'
 
-  # Enable "Edit this page" links for 'doc' page type.
-  # Disabled by default. Uncomment to enable. Requires 'BookRepo' param.
-  # Edit path must point to root directory of repo.
-  BookEditPath: edit/main
-
-  # Configure the date format used on the pages
+  # (Optional, default 'January 2, 2006') Configure the date format used on the pages
   # - In git information
   # - In blog posts
-  BookDateFormat: "January 2, 2006"
+  # https://gohugo.io/functions/time/format/
+  # BookDateFormat: "January 2, 2006"
 
   # (Optional, default true) Enables search function with flexsearch,
   # Index is built on fly, therefore it might slowdown your website.
   # Configuration for indexing can be adjusted in i18n folder per language.
-  BookSearch: true
+  # BookSearch: true
 
   # (Optional, default true) Enables comments template on pages
   # By default partals/docs/comments.html includes Disqus template
@@ -111,12 +98,14 @@ params:
   # /!\ This is an experimental feature, might be removed or changed at any time
   # (Optional, experimental, default false) Enables portable links and link checks in markdown pages.
   # Portable links meant to work with text editors and let you write markdown without {{< relref >}} shortcode
-  # Theme will print warning if page referenced in markdown does not exists.
-  # BookPortableLinks: true
+  # Theme will print warning or error if page referenced in markdown does not exists.
+  # Possible values are false | 'warning' | 'error'
+  # BookPortableLinks: 'warning'
 
   # /!\ This is an experimental feature, might be removed or changed at any time
   # (Optional, experimental, default false) Enables service worker that caches visited pages and resources for offline use.
-  # BookServiceWorker: true
+  # can be false, true or 'precache', precache will try to download all content pages on install.
+  # BookServiceWorker: "precache"
 
   # /!\ This is an experimental feature, might be removed or changed at any time
   # (Optional, experimental, default false) Enables a drop-down menu for translations only if a translation is present.

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,34 +1,12 @@
+{{- $destination := .Destination -}}
 {{- if .Page.Site.Params.BookPortableLinks -}}
-  {{- template "portable-link" . -}}
-{{- else -}}
-  {{- $u := urls.Parse .Destination -}}
-  <a href="{{ .Destination | safeURL }}"
-    {{- with .Title }} title="{{ . }}"{{ end -}}
-    {{- if $u.IsAbs }} rel="external" target="_blank"{{ end -}}
-  >
-    {{- with .Text }}{{ . }}{{ end -}}
-  </a>
+  {{- $destination = partial "docs/links/portable-link" . -}}
 {{- end -}}
-
-{{- define "portable-link" -}}
-  {{- $destination := .Destination }}
-  {{- $isRemote := or (in .Destination ":") (strings.HasPrefix .Destination "//") }}
-  {{- if not $isRemote }}
-    {{- $url := urls.Parse .Destination }}
-    {{- $path := strings.TrimSuffix "/_index.md" $url.Path }}
-    {{- $path = strings.TrimSuffix "/_index" $path }}
-    {{- $path = strings.TrimSuffix ".md" $path }}
-    {{- $page := .Page.GetPage $path }}
-    {{- if $page }}
-      {{- $destination = $page.RelPermalink }}
-      {{- if $url.Fragment }}
-        {{- $destination = print $destination "#" $url.Fragment }}
-      {{- end }}
-    {{- else if fileExists (print .Page.File.Dir .Destination) }}
-      <!-- Nothing -->
-    {{- else -}}
-      {{- warnf "Page '%s' not found in '%s'" .Destination .Page.File }}
-    {{- end }}
-  {{- end }}
-  <a href="{{ $destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
-{{- end -}}
+{{- $u := urls.Parse $destination -}}
+<a href="{{ .Destination | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+  {{- if $u.IsAbs }} rel="external" target="_blank"{{ end -}}
+>
+  {{- with .Text }}{{ . }}{{ end -}}
+</a>
+{{- /**/ -}}

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -1,5 +1,5 @@
 <div class="r-logo">
     <a class="flex align-center" href="{{ cond (not .Site.Home.File) .Sites.Default.Home.RelPermalink .Site.Home.RelPermalink }}">
-        <img src="/svg/resty-logo.svg" alt="Resty Logo" height="60px" />
+        <img src="/svg/resty-logo.svg" alt="Resty Logo" width="100%" />
     </a>
 </div>

--- a/layouts/partials/docs/inject/menu-before.html
+++ b/layouts/partials/docs/inject/menu-before.html
@@ -1,7 +1,0 @@
-<ul>
-    <li><a href="/docs/upgrading-to-v3/">Upgrading to v3</a>
-        <ul>
-            <li><a href="/docs/new-features-and-enhancements/">New Features and Enhancements</a></li>
-        </ul>
-    </li>
-</ul>


### PR DESCRIPTION
Hi!

This PR would update hugo-book theme to v12.
I also took liberty to adjust size of logo and rewrite `hint` shortcodes into markdown alerts that are now supported. Also menu-before inject template was replaced with hugo native menus.

Everything should feel the same as before, notable change from theme point of view that it is not shipped with custom font by default anymore, and relies on `system-ui`.

<img width="1512" height="817" alt="image" src="https://github.com/user-attachments/assets/1eb6275f-33e9-4b7e-a729-bb88ded7f838" />
